### PR TITLE
Further implement the Optanon cookie consent support

### DIFF
--- a/kookenka2.html
+++ b/kookenka2.html
@@ -3169,6 +3169,8 @@ var sizeme_options = {
 	buttonize: "no",
 	pluginVersion: "MAG1-1.0.4",
 	shopType: "magento",
+    debugState: true,
+    trackingConsentMethod: "Optanon",
 	uiOptions: {}
 };
 


### PR DESCRIPTION
Introduced a new optional option `trackingConsentMethod` for enabling a specific tracking consent process. Only supported value for now is "Optanon". If the option is set, the tracking code will not send any tracking calls until the Optanon cookie is found and is set to allow tracking. The tracking calls are queued and executed sequentially if/when the tracking is found to be enabled.

If option is not set, will send tracking codes normally.

Google's analytics.js is loaded in any case, unless already loaded by some other script.

Fixes #103. 