### PR TITLE
Toggler for hiding and showing sizeme content

### DIFF
--- a/index1.html
+++ b/index1.html
@@ -831,7 +831,9 @@
         gaTrackingId: "UA-40735596-2",
         shopType: "magento",
         debugState: true,
-        uiOptions: {}
+        uiOptions: {
+            toggler: true
+        }
     };
 </script>
 

--- a/src/api/actions.js
+++ b/src/api/actions.js
@@ -21,6 +21,7 @@ export const SELECT_SIZE = "SELECT_SIZE";
 export const SET_TOOLTIP = "SET_TOOLTIP";
 export const SET_AB_STATUS = "SET_AB_STATUS";
 export const SET_MATCH_STATE = "SET_MATCH_STATE";
+export const SET_SIZEME_HIDDEN = "SET_SIZEME_HIDDEN";
 
 export const { checkToken, fetchToken, resolveToken, clearToken } =
     createActions(CHECK_TOKEN, FETCH_TOKEN, RESOLVE_TOKEN, CLEAR_TOKEN);
@@ -35,3 +36,4 @@ export const { selectSize } = createActions(SELECT_SIZE);
 export const { setTooltip } = createActions(SET_TOOLTIP);
 export const { setAbStatus } = createActions(SET_AB_STATUS);
 export const { setMatchState } = createActions(SET_MATCH_STATE);
+export const { setSizemeHidden } = createActions(SET_SIZEME_HIDDEN);

--- a/src/api/reducers.js
+++ b/src/api/reducers.js
@@ -144,6 +144,8 @@ const matchState = handleAction(actions.SET_MATCH_STATE, (state, action) => acti
     state: null
 });
 
+const sizemeHidden = handleAction(actions.SET_SIZEME_HIDDEN, (state, action) => action.payload, false);
+
 const rootReducer = combineReducers({
     authToken,
     signupStatus,
@@ -154,7 +156,8 @@ const rootReducer = combineReducers({
     selectedSize,
     tooltip,
     abStatus,
-    matchState
+    matchState,
+    sizemeHidden
 });
 
 export default rootReducer;

--- a/src/api/sizeme-api.js
+++ b/src/api/sizeme-api.js
@@ -497,6 +497,13 @@ function findVisibleElement (selector) {
     return null;
 }
 
+function setSizemeHidden (sizemeHidden) {
+    return dispatch => {
+        dispatch(actions.setSizemeHidden(sizemeHidden));
+        localStorage.setItem("sizemeToggledVisible", JSON.stringify(!sizemeHidden));
+    };
+}
+
 export {
     sizemeStore,
     resolveAuthToken,
@@ -509,5 +516,6 @@ export {
     selectSize,
     contextAddress,
     cdnLocation,
-    findVisibleElement
+    findVisibleElement,
+    setSizemeHidden
 };

--- a/src/api/uiOptions.js
+++ b/src/api/uiOptions.js
@@ -2,7 +2,8 @@
 
 const general = {
     disableSizeGuide: false,
-    lang: "en"
+    lang: "en",
+    toggler: false
 };
 
 const shops = {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -8,7 +8,8 @@
     "sizingBarSplashNoSize": "No size was found based on your measurement",
     "sizingBarSplashMatch": "We recommend size <strong>{{- sizeName}}</strong> for you",
     "sizingBarFitTooltip": "This indicates how size <strong>{{- selectedSize}}</strong> will fit you",
-    "sizingBarRecommendationTooltip": "We recommend that your fit is close to this area"
+    "sizingBarRecommendationTooltip": "We recommend that your fit is close to this area",
+    "togglerText": "Find my size"
   },
   "detailed": {
     "buttonText": "Detailed view of fit",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -8,7 +8,8 @@
     "sizingBarSplashNoSize": "Valitse koko, niin näytämme miten se sopii sinulle",
     "sizingBarSplashMatch": "Suosittelemme sinulle kokoa <strong>{{- sizeName}}</strong>",
     "sizingBarFitTooltip": "Tämä näyttää miten koko <strong>{{- selectedSize}}</strong> sopii sinulle",
-    "sizingBarRecommendationTooltip": "Tämän tuotteen kohdalla suosittelemme tätä sopivuutta"
+    "sizingBarRecommendationTooltip": "Tämän tuotteen kohdalla suosittelemme tätä sopivuutta",
+    "togglerText": "Find my size"
   },
   "detailed": {
     "windowTitle": "Sopivuustiedot tuotteelle",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -8,7 +8,8 @@
     "sizingBarSplashNoSize": "Select a size to see your fit",
     "sizingBarSplashMatch": "We selected size <strong>{{- sizeName}}</strong> for you",
     "sizingBarFitTooltip": "This indicates how size <strong>{{- selectedSize}}</strong> will fit you",
-    "sizingBarRecommendationTooltip": "We recommend that your fit is around this area"
+    "sizingBarRecommendationTooltip": "We recommend that your fit is around this area",
+    "togglerText": "Find my size"
   },
   "detailed": {
     "windowTitle": "Detaljerad Bild för",

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -1,2 +1,17 @@
 $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome.scss";
+
+//noinspection CssNoGenericFontName
+.sizeme-toggler a i::after {
+  font-family: "FontAwesome";
+  padding-left: 0.5em;
+  vertical-align: middle;
+}
+
+.sizeme-toggler.sm-hidden a i::after {
+  content: "\f063";
+}
+
+.sizeme-toggler.sm-visible a i::after {
+  content: "\f062";
+}


### PR DESCRIPTION
If sizeme_options.uiOptions contains property `toggler` with value `true`, the visibility toggler functionality is activated. A new div-element with class `sizeme-toggler` is inserted before the sizeme content, containing a link that toggles the visibility of the Sizeme component. 

The Sizeme-component is by default hidden, unless there's a local storage item `sizemeToggledVisible` that is set `true`. 

A function to programmatically toggle the visibility is added to the uiOptions-object, called `toggleVisible`. It can be called without parameters to just toggle the current value, or with a boolean argument to explicitly set the visibility. Custom togglers should use this function to control the visibility.

@nomasi: check the correct translations of "Find my size" for Finnish and Swedish.

Fixes #106 