### PR TITLE
Rough attempt in solving a fringe fitting issue

### DIFF
--- a/src/api/sizeme-api.js
+++ b/src/api/sizeme-api.js
@@ -416,7 +416,7 @@ function match (doSelectBestFit = true) {
                         if ((Object.keys(singleResult.matchMap).length === 1) &&
                             (Object.keys(singleResult.matchMap)[0] === "pant_waist")) {
                             // move the single totalFit to the optimal by force
-                            if (singleResult.matchMap.pant_waist.overlap >= 0) {
+                            if (singleResult.matchMap.pant_waist.componentFit >= 1000) {
                                 singleResult.totalFit = (optFit - 1000) +
                                                         singleResult.totalFit -
                                                         Math.floor(singleResult.matchMap.pant_waist.componentStretch / 20);

--- a/src/api/sizeme-api.js
+++ b/src/api/sizeme-api.js
@@ -408,6 +408,22 @@ function match (doSelectBestFit = true) {
                             .map(([sku, res]) => ({ [skuMap.get(sku)]: res }))
                     );
                 }
+                // time for the single fitted pantWaist exception
+                // run thru all results and see if we have a single pantWaist entered
+                const optFit = product.item.fitRecommendation ? product.item.fitRecommendation : DEFAULT_OPTIMAL_FIT;
+                Object.entries(result).forEach(([key, singleResult]) => {
+                    if (singleResult.matchMap) {
+                        if ((Object.keys(singleResult.matchMap).length === 1) &&
+                            (Object.keys(singleResult.matchMap)[0] === "pant_waist")) {
+                            // move the single totalFit to the optimal by force
+                            if (singleResult.matchMap.pant_waist.overlap >= 0) {
+                                singleResult.totalFit = (optFit - 1000) +
+                                                        singleResult.totalFit -
+                                                        Math.floor(singleResult.matchMap.pant_waist.componentStretch / 20);
+                            }
+                        }
+                    }
+                });
                 const fitResults = Object.entries(result);
                 // if user is logged in, don't care about the accuracy. If not,
                 // filter out results where accuracy is 0


### PR DESCRIPTION
This is my rough attempt at fixing a long standing issue with pant waist fitting.  

Our current fitting math is wonderfully great at matching stuff that _is supposed to have_ space between the product and the human (shoe lengths, shirts etc).  Pant waists are different, that they work best when there is no overlap.  But the rest of the pants (every other measurements besides the waist) could and should be more loose.  

The problem is mostly only evident when the user has only entered the pant waist value and _this fix only applies to that scenario_.  The code looks for that scenario and manipulates the totalFit value of the single size, so that the recommendation engine can work from there.  

The code itself is fairly rough due to lack of super-concise js skills, so it can be rewritten in a more js way.  

The other question was that does this work-around even belong in the frontend?  The only reason to test it here is the fact that the product's fitRecommendation is here, and also that, this js is remotely understandable (compared to the scala of the backend).  

But this whole solution is still open for debate as this is somewhat of a bubblegum-fix for the problem.  