### PR TITLE
Implement firstRecommendation-option

### DIFF
--- a/src/api/SizeSelector.js
+++ b/src/api/SizeSelector.js
@@ -58,6 +58,8 @@ class DefaultSelect extends AbstractSelect {
         }
     }
 
+    getSelectedSize = () => this.el.value;
+
     clearSelection = () => {
         this.el.value = "";
     };
@@ -103,6 +105,15 @@ class SwatchesSelect extends AbstractSelect {
                 this.sizeMapper.push([sizeValue, textSpan.textContent.trim()]);
             }
         }
+
+        this.getSelectedSize = () => {
+            const selected = element.querySelector("li.selected");
+            if (selected) {
+                return getId(selected);
+            } else {
+                return "";
+            }
+        };
     }
 
     clone = () => {
@@ -143,6 +154,15 @@ class KooKenkaSwatchesSelect extends AbstractSelect {
             }
         };
 
+        this.getSelectedSize = () => {
+            const selected = element.querySelector("li.li_selected");
+            if (selected) {
+                return getId(selected);
+            } else {
+                return "";
+            }
+        };
+
         const options = element.querySelectorAll("li");
         const mkSelectFn = option => () => option.click();
         for (let i = 0; i < options.length; i++) {
@@ -166,6 +186,8 @@ class HarrysOfLondonSelect extends AbstractSelect {
                 return "";
             }
         };
+
+        this.getSelectedSize = this.getSize;
 
         const sizeMaps = {};
         const selectorMap = {};
@@ -239,6 +261,7 @@ const getClone = () => {
     return selector ? selector.clone() : null;
 };
 const getSizeMapper = () => selector.sizeMapper;
+const getSelectedSize = () => selector.getSelectedSize();
 
 
-export default { initSizeSelector, setSelectedSize, getClone, getSizeMapper };
+export default { initSizeSelector, setSelectedSize, getClone, getSizeMapper, getSelectedSize };

--- a/src/api/reducers.js
+++ b/src/api/reducers.js
@@ -133,10 +133,12 @@ const tooltip = handleAction(actions.SET_TOOLTIP, (state, action) => action.payl
 
 const selectedSize = handleAction(actions.SELECT_SIZE, (state, action) => ({
     ...state,
-    ...action.payload
+    ...action.payload,
+    firstMatch: false
 }), {
     size: "",
-    auto: false
+    auto: false,
+    firstMatch: true
 });
 
 const abStatus = handleAction(actions.SET_AB_STATUS, (state, action) => action.payload, null);

--- a/src/api/sizeme-api.js
+++ b/src/api/sizeme-api.js
@@ -467,10 +467,15 @@ function saveProfile () {
 
 function selectSize (size, auto) {
     return (dispatch, getState) => {
-        if (auto) {
-            SizeSelector.setSelectedSize(size);
+        const firstMatch = !uiOptions.firstRecommendation && getState().selectedSize.firstMatch;
+        if (!firstMatch) {
+            if (auto) {
+                SizeSelector.setSelectedSize(size);
+            }
+            dispatch(actions.selectSize({size, auto}));
+        } else {
+            dispatch(actions.selectSize({size: SizeSelector.getSelectedSize(), auto: false}));
         }
-        dispatch(actions.selectSize({ size, auto }));
 
         let match = null;
         let state = "match";
@@ -491,6 +496,9 @@ function selectSize (size, auto) {
             }
         } else {
             state = "no-fit";
+        }
+        if (firstMatch && matchResult.recommendedFit === currentSize) {
+            dispatch(actions.selectSize({auto: true}));
         }
         dispatch(actions.setMatchState({ match, state }));
     };

--- a/src/api/uiOptions.js
+++ b/src/api/uiOptions.js
@@ -1,6 +1,7 @@
 const general = {
     disableSizeGuide: false,
-    toggler: false
+    toggler: false,
+    firstRecommendation: true
 };
 
 const shops = {
@@ -28,7 +29,7 @@ const shops = {
         invokeEvent: "change",
         addToCartElement: "button.AddToBasketButton",
         addToCartEvent: "click",
-        firstRecommendation: true,
+        firstRecommendation: false,
         sizeSelectorType: "default"
     }
 };


### PR DESCRIPTION
 which disables automatic size selection on page load. This prevents Vilkas-webstores ending up in a endless loop.

- no size is selected automatically on page load even if there is no pre-selected size. For some reason Vilkas-teststore didn't play well with that idea at all.
- if the pre-selected size is the recommended size, the recommendation splash is shown when the page is loaded


Fixes #138