### PR TITLE
Add resizeHide as false to measurement field tooltip/guide

### DIFF
--- a/src/common/SizeForm.jsx
+++ b/src/common/SizeForm.jsx
@@ -146,7 +146,7 @@ class SizeForm extends React.Component {
                         ).orElse(null)}
                     </div>
                 ))}
-                <ReactTooltip id="input-tooltip" type="light" getContent={this.tooltipContent(t)}/>
+                <ReactTooltip id="input-tooltip" type="light" resizeHide={false} getContent={this.tooltipContent(t)}/>
                 <Modal isOpen={this.state.guideModalOpen}
                        onRequestClose={this.closeGuideModal}
                        className="measurement-guide-modal"


### PR DESCRIPTION
This prevents a semi-bug where the measurement guide hides on mobile.  On input field focus, the tooltip is initially shown, but then the mobile keypad opens up, changes the window size and hides the fresh tooltip.  

This fix causes weird effects on desktop if you just change the window size in mid-stream.  It's ok.  