### PR TITLE
Fix pant waist stuff

### DIFF
--- a/src/api/ProductModel.js
+++ b/src/api/ProductModel.js
@@ -1250,6 +1250,7 @@ export {
     stretchFactor,
     DEFAULT_OPTIMAL_FIT,
     DEFAULT_OPTIMAL_STRETCH,
+    fitLabelsAndColors,
 };
 
 

--- a/src/api/sizeme-api.js
+++ b/src/api/sizeme-api.js
@@ -373,9 +373,10 @@ function getRecommendedFit (fitResults, optimalFit) {
             .filter(([, res]) => res.accuracy > 0)
             .reduce(([accSize, fit], [size, res]) => {
                 let maxStretchArr = [];
-                Object.entries(res.matchMap).forEach(([oKey, oValue]) => { maxStretchArr.push( oValue.componentStretch / stretchFactor(oKey) );});
+                Object.entries(res.matchMap).forEach(([oKey, oValue]) => { maxStretchArr.push( oValue.componentStretch / stretchFactor(oKey) ); });
                 let maxStretch = Math.max.apply(null, maxStretchArr);
-                const newFit = (Math.abs(res.totalFit - optFit) * 100) + Math.abs(maxStretch - optStretch);
+                let normalizedTotalFit = (((res.totalFit <= 1000) && (res.totalFit > 990)) ? 1000 : res.totalFit);
+                const newFit = (Math.abs(normalizedTotalFit - optFit) * 100) + Math.abs(maxStretch - optStretch);
                 if (newFit <= (maxDist * 100) && (!accSize || newFit < fit)) {
                     return [size, newFit];
                 } else {

--- a/src/common/SizingBar.jsx
+++ b/src/common/SizingBar.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { withTranslation } from "react-i18next";
 import "./SizingBar.scss";
-import ProductModel, { DEFAULT_OPTIMAL_FIT, DEFAULT_OPTIMAL_STRETCH, fitRanges, stretchFactor } from "../api/ProductModel";
+import ProductModel, { DEFAULT_OPTIMAL_FIT, DEFAULT_OPTIMAL_STRETCH, fitRanges, stretchFactor, fitLabelsAndColors } from "../api/ProductModel";
 import ReactTooltip from "react-tooltip";
 import SizeSelector from "../api/SizeSelector";
 
@@ -12,9 +12,8 @@ const getSizename = (selectedSize) =>
         .map(([, sizeName]) => sizeName)[0] || selectedSize;
 
 const getValueBasedFitLabel = (value) => {
-    const labels = ["too_small","slim","regular","loose","too_big","too_big"];
-    let labelKey = Math.floor(value / 20);
-    return (labels[labelKey] !== "undefined" ? labels[labelKey] : "regular");
+    let labelKey = Math.min(Math.floor(value / 20), fitLabelsAndColors.length - 1);
+    return (typeof fitLabelsAndColors[labelKey] !== "undefined" ? fitLabelsAndColors[labelKey].label : "regular");
 };
 
 const FitIndicator = (props) => {

--- a/src/common/SizingBar.jsx
+++ b/src/common/SizingBar.jsx
@@ -11,13 +11,19 @@ const getSizename = (selectedSize) =>
     SizeSelector.getSizeMapper().filter(([size]) => size === selectedSize)
         .map(([, sizeName]) => sizeName)[0] || selectedSize;
 
+const getValueBasedFitLabel = (value) => {
+    const labels = ["too_small","slim","regular","loose","too_big","too_big"];
+    let labelKey = Math.floor(value / 20);
+    return (labels[labelKey] !== "undefined" ? labels[labelKey] : "regular");
+};
+
 const FitIndicator = (props) => {
     const left = `calc(${props.value}% - 9px`;
     const { selectedSize, t } = props;
     return (
         <div>
             <svg className="indicator" style={{ left }} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
-                <polygon className={props.fitRange.label} points="5,0 10,10 0,10 5,0"
+                <polygon className={getValueBasedFitLabel(props.value)} points="5,0 10,10 0,10 5,0"
                          data-tip data-for="fitTooltip"/>
             </svg>
             <ReactTooltip id="fitTooltip" type="light" class="indicator-tooltip">

--- a/src/common/SizingBar.jsx
+++ b/src/common/SizingBar.jsx
@@ -126,7 +126,6 @@ class SizingBar extends React.Component {
         let { fitRecommendation } = this.props;
         if (fitRecommendation === 1000) {
             let maxStretch = DEFAULT_OPTIMAL_STRETCH;
-            let minStretchFactor = 1;
             let newPos = 50;
             if (matchMap) {
                 const maxStretchArr = [];
@@ -136,13 +135,11 @@ class SizingBar extends React.Component {
                     minStretchFactorArr.push( stretchFactor(oKey) );
                 });
                 maxStretch = Math.max.apply(null, maxStretchArr);
-                minStretchFactor = Math.min.apply(null, minStretchFactorArr);
                 if (value > 1000) {
                     newPos = Math.min(100, 60 + ((value - 1000) / 55 * 40));
                 } else if ((value <= 1000) && (value > 990)) {
                     const stretchBreakpoint = 2 * DEFAULT_OPTIMAL_STRETCH;
                     newPos = (maxStretch > stretchBreakpoint) ? Math.max(20, 40 - ((maxStretch - stretchBreakpoint) / (100 - stretchBreakpoint) * 20)) : Math.max(40, 60 - (maxStretch / stretchBreakpoint * 20));
-                    if (minStretchFactor > 1) newPos = Math.max(0, Math.min(100, ((newPos - 50) * minStretchFactor) + 50));
                 } else {
                     newPos = Math.max(0, 20 - ((1000 - value) / 55 * 20));
                 }


### PR DESCRIPTION
Fixed a few weird issues with stretchy clothing:

* fixed the recommendation with a normalized totalFit value (the 990 is guessed, 995 might be more accurate in fact)
* removed the scaling effect when all sizes stretch a lot (was added at Perfuro request, but misleading)
* fixed the indicator labeling on stretchy stuff
