### PR TITLE
Move the pant waist special handling to the front end

### DIFF
--- a/index5b.html
+++ b/index5b.html
@@ -679,7 +679,7 @@
                                 itemType: "2.0.0.6.1.3.1",
                                 itemLayer: 1,
                                 itemThickness: 2,
-                                itemStretch: 10,
+                                itemStretch: 0,
                                 fitRecommendation: 0,
                                 measurements: {
                                     "7": {

--- a/src/api/ProductModel.js
+++ b/src/api/ProductModel.js
@@ -1253,6 +1253,22 @@ const stretchFactor = (measurement) => {
     return factor;
 };
 
+const useStretchingMath = (matchMap, fitRecommendation) => {
+    if (fitRecommendation === 1000) return true;
+    if (!matchMap) return false;
+    if (matchMap.pant_waist !== undefined) {
+        let numOfImportantMeasurements = 0;
+        Object.entries(matchMap).forEach(([, oValue]) => {
+            if (oValue.importance === 1) numOfImportantMeasurements++;
+            if ((oValue.importance === -1) && (oValue.componentFit < 1000)) numOfImportantMeasurements++;
+        });
+        if (numOfImportantMeasurements === 1) {
+            return true;
+        }
+    }
+    return false;
+};
+
 const DEFAULT_OPTIMAL_FIT = 1070;
 const DEFAULT_OPTIMAL_STRETCH = 5;
 
@@ -1261,6 +1277,7 @@ export {
     fitRanges,
     getResult,
     stretchFactor,
+    useStretchingMath,
     DEFAULT_OPTIMAL_FIT,
     DEFAULT_OPTIMAL_STRETCH,
     fitLabelsAndColors,

--- a/src/common/SizingBar.jsx
+++ b/src/common/SizingBar.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { withTranslation } from "react-i18next";
 import "./SizingBar.scss";
-import ProductModel, { DEFAULT_OPTIMAL_FIT, DEFAULT_OPTIMAL_STRETCH, fitRanges, stretchFactor, fitLabelsAndColors } from "../api/ProductModel";
+import ProductModel, { DEFAULT_OPTIMAL_FIT, DEFAULT_OPTIMAL_STRETCH, fitRanges, stretchFactor, useStretchingMath, fitLabelsAndColors } from "../api/ProductModel";
 import ReactTooltip from "react-tooltip";
 import SizeSelector from "../api/SizeSelector";
 
@@ -129,7 +129,7 @@ class SizingBar extends React.Component {
 
     getFitPosition (value,matchMap) {
         let { fitRecommendation } = this.props;
-        if (fitRecommendation === 1000) {
+        if (useStretchingMath(matchMap, fitRecommendation)) {
             let maxStretch = DEFAULT_OPTIMAL_STRETCH;
             let newPos = 50;
             if (matchMap) {
@@ -141,7 +141,11 @@ class SizingBar extends React.Component {
                 });
                 maxStretch = Math.max.apply(null, maxStretchArr);
                 if (value > 1000) {
-                    newPos = Math.min(100, 60 + ((value - 1000) / 55 * 40));
+                    if (fitRecommendation === 1000) {
+                        newPos = Math.min(100, 60 + ((value - 1000) / 55 * 40));
+                    } else {
+                        newPos = Math.min(100, 60 + ((value - 1000) / 55 * 10));
+                    }
                 } else if ((value <= 1000) && (value > 990)) {
                     const stretchBreakpoint = 2 * DEFAULT_OPTIMAL_STRETCH;
                     newPos = (maxStretch > stretchBreakpoint) ? Math.max(20, 40 - ((maxStretch - stretchBreakpoint) / (100 - stretchBreakpoint) * 20)) : Math.max(40, 60 - (maxStretch / stretchBreakpoint * 20));


### PR DESCRIPTION
* added a useStretchingMath function to check whether there is only one important measurement pair present
- the pant waist measurement alone is not always the only important one, if the componentFit < 1000, then this is important too
* changed the getRecommendedFit so that all cases are handled similarly
* the sizing bar handles the overlap part differently whether the recommendation is 1000 or not
* index5b test case changed to a product that doesn't stretch, but the pant waist part is elastic