### PR TITLE
Fix modal close button location

### DIFF
--- a/src/sizeguide/SizeGuide.scss
+++ b/src/sizeguide/SizeGuide.scss
@@ -136,8 +136,9 @@ a.link-btn.size-guide {
       .size-guide-close {
         color: #666;
         text-decoration: none;
-        float: right;
         cursor: pointer;
+        position: absolute;
+        right: 15px;
 
         &:hover {
           color: #000;


### PR DESCRIPTION
* if modal was really narrow, the close button would drop down a line and wouldn't work properly