### PR TITLE
Further fix for the input tooltip hiding problem

### DIFF
--- a/src/common/SizeForm.jsx
+++ b/src/common/SizeForm.jsx
@@ -146,7 +146,7 @@ class SizeForm extends React.Component {
                         ).orElse(null)}
                     </div>
                 ))}
-                <ReactTooltip id="input-tooltip" type="light" resizeHide={false} getContent={this.tooltipContent(t)}/>
+                <ReactTooltip id="input-tooltip" type="light" resizeHide={false} scrollHide={false} getContent={this.tooltipContent(t)}/>
                 <Modal isOpen={this.state.guideModalOpen}
                        onRequestClose={this.closeGuideModal}
                        className="measurement-guide-modal"


### PR DESCRIPTION
* tooltips disappear when activating input fields
  * especially in mobile when the mobile keyboard jumps in
  * we already had resizeHide at false, now scrolling too