### PR TITLE
Fix stretching rec math

### DIFF
--- a/src/api/sizeme-api.js
+++ b/src/api/sizeme-api.js
@@ -373,6 +373,7 @@ function getRecommendedFit (fitResults, optimalFit) {
     const [bestMatch] = fitResults
         .filter(([, res]) => res.accuracy > 0)
         .reduce(([accSize, fit], [size, res]) => {
+            if (res.totalFit < 1000) return [accSize, fit];
             if (useStretchingMath(res.matchMap, optFit)) {
                 let maxStretchArr = [];
                 Object.entries(res.matchMap).forEach(([oKey, oValue]) => { maxStretchArr.push( oValue.componentStretch / stretchFactor(oKey) ); });

--- a/src/api/sizeme-api.js
+++ b/src/api/sizeme-api.js
@@ -377,8 +377,7 @@ function getRecommendedFit (fitResults, optimalFit) {
                 let maxStretchArr = [];
                 Object.entries(res.matchMap).forEach(([oKey, oValue]) => { maxStretchArr.push( oValue.componentStretch / stretchFactor(oKey) ); });
                 const maxStretch = Math.max.apply(null, maxStretchArr);
-                const normalizedTotalFit = (((res.totalFit <= 1000) && (res.totalFit > 990)) ? 1000 : res.totalFit);
-                const newFit = (Math.abs(normalizedTotalFit - 1000) * 100) + Math.abs(maxStretch - optStretch);
+                const newFit = (Math.abs(res.totalFit - 1000) * 100) + Math.abs(maxStretch - optStretch);
                 if (newFit <= (maxDist * 100) && (!accSize || newFit < fit)) {
                     return [size, newFit];
                 } else {

--- a/src/common/SizingBar.jsx
+++ b/src/common/SizingBar.jsx
@@ -146,7 +146,7 @@ class SizingBar extends React.Component {
                     } else {
                         newPos = Math.min(100, 60 + ((value - 1000) / 55 * 10));
                     }
-                } else if ((value <= 1000) && (value > 990)) {
+                } else if (value == 1000) {
                     const stretchBreakpoint = 2 * DEFAULT_OPTIMAL_STRETCH;
                     newPos = (maxStretch > stretchBreakpoint) ? Math.max(20, 40 - ((maxStretch - stretchBreakpoint) / (100 - stretchBreakpoint) * 20)) : Math.max(40, 60 - (maxStretch / stretchBreakpoint * 20));
                 } else {


### PR DESCRIPTION
Back in the day, the backend returned totalFits between 990 and 1000 even when the item was stretching "normally" (stretch under 100).  By all accounts, this backend behaviour has (hopefully) been fixed, so we don't have to normalize values between 990 and 1000.  

Values under 1000 are always too small (as in won't fit the person) and the recommendation engine was changed to ensure this as well.  