### PR TITLE
Add gender guessing from product name and/or SKU

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Application expects to find an object named `sizeme_options` (TODO: rename to `S
   - [skinClasses] (_String_): contents will be appended to the class attribute of SizeMe container element. Empty by default.
   - [toggler] (_Boolean_): enable/disable functionality that can be used to toggle the visibility of SizeMe content
   - [flatMeasurements] (_Boolean_): show product circumference measurements (chest, waist etc) as measured on a flat surface in the size guide. Default: true
+  - [matchGenderFromNameMale] (_String_): a reg exp string to match that product is for (real) men. Otherwise measuring videos etc. default to women. Default: ""
 - [additionalTranslations] (_Object_): Optionally override translations defined under ['i18n'](src/i18n). Example of how to
   override the Swedish translation for chest:
 

--- a/src/api/uiOptions.js
+++ b/src/api/uiOptions.js
@@ -3,6 +3,7 @@ const general = {
   toggler: false,
   firstRecommendation: true,
   flatMeasurements: true,
+  matchGenderFromNameMale: "",
 };
 
 const shops = {

--- a/src/i18n/ar.json
+++ b/src/i18n/ar.json
@@ -13,7 +13,8 @@
     "togglerText": "ابحث عن مقاسي",
     "sizemeTooltip": "يدعم هذا المنتج ”سايزمي” ، وهي خدمة توصي بأفضل حجم مناسب من خلال مقارنة القياسات الفعلية لقياسات هذا المنتج.",
     "sizemeTooltipLink": "قراءة المزيد",
-    "sizeItself": "مقاس"
+    "sizeItself": "مقاس",
+    "defaultProfileName": "ملفي"
   },
   "detailed": {
     "buttonText": "صورة تفصيلية للمقاس",

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -13,7 +13,8 @@
     "togglerText": "Finde meine Größe",
     "sizemeTooltip": "Dieses Produkt unterstützt SizeMe, einen Service, der dir aufgrund deiner Körpermaße die dir am besten  passende Größe vorschlägt - indem deine Maße mit den Maßen des Produktes verglichen werden.",
     "sizemeTooltipLink": "Lies mehr",
-    "sizeItself": "Größe"
+    "sizeItself": "Größe",
+    "defaultProfileName": "Mein Profil"
   },
   "detailed": {
     "buttonText": "Detaillierte Ansicht der Passform",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -13,7 +13,8 @@
     "togglerText": "Find my size",
     "sizemeTooltip": "This product supports SizeMe, a service that recommends the best fitting size by comparing your physical measurements to the measurements of this product.",
     "sizemeTooltipLink": "Read more",
-    "sizeItself": "Size"
+    "sizeItself": "Size",
+    "defaultProfileName": "My profile"
   },
   "detailed": {
     "buttonText": "Detailed view of fit",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -13,7 +13,8 @@
     "togglerText": "Löydä oikea kokosi",
     "sizemeTooltip": "Tässä tuotteessa on käytössä SizeMe-palvelu, joka suosittelee sopivinta kokoa vertaamalla mittojasi tämän tuotteen mittoihin.",
     "sizemeTooltipLink": "Lue lisää",
-    "sizeItself": "Koko"
+    "sizeItself": "Koko",
+    "defaultProfileName": "Minun mittani"
   },
   "detailed": {
     "windowTitle": "Sopivuustiedot tuotteelle",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -13,7 +13,8 @@
     "togglerText": "Hitta min storlek",
     "sizemeTooltip": "Denna produkt stöder SizeMe, en tjänst som rekommenderar den bästa passningsstorleken genom att jämföra dina fysiska mätningar med mätningarna på denna produkt.",
     "sizemeTooltipLink": "Läs mer",
-    "sizeItself": "Storlek"
+    "sizeItself": "Storlek",
+    "defaultProfileName": "Min profil"
   },
   "detailed": {
     "windowTitle": "Detaljerad Bild för",

--- a/test-sites/index1.html
+++ b/test-sites/index1.html
@@ -621,7 +621,7 @@
                     <script type="text/javascript">
                         //<![CDATA[
                         var sizeme_product = {
-                            name: "T-SHIRT",
+                            name: "T-SHIRT FOR MEN",
                             item: {
                                 itemType: "1.1.2.3.0.4.0",
                                 itemLayer: 0,
@@ -853,7 +853,8 @@
         debugState: true,
         uiOptions: {
             toggler: true,
-            flatMeasurements: false
+            flatMeasurements: false,
+            matchGenderFromNameMale: " men"
         }
     };
 </script>


### PR DESCRIPTION
Added an uiOption where a shop can define if a certain product is for men.  We have two sets of measurement videos (and some variation in instructions too) and they all default to women, so using this feature, we can show the right one hopefully.  