### PR TITLE
Fix for swatches variation

### DIFF
--- a/src/api/SizeSelector.js
+++ b/src/api/SizeSelector.js
@@ -19,7 +19,9 @@ class AbstractSelect {
         if (this.sizeMapper.find(([s]) => s === size)) {
           selectSize(size);
         } else {
-          if (this.allowEmptySizeSelection) selectSize("");
+          if (this.allowEmptySizeSelection) {
+            selectSize("");
+          }
         }
       },
       useCapture

--- a/src/api/SizeSelector.js
+++ b/src/api/SizeSelector.js
@@ -10,6 +10,7 @@ class AbstractSelect {
     this.el = element;
     this.selectors = {};
     this.sizeMapper = [];
+    this.allowEmptySizeSelection = true;
 
     element.addEventListener(
       event,
@@ -18,7 +19,7 @@ class AbstractSelect {
         if (this.sizeMapper.find(([s]) => s === size)) {
           selectSize(size);
         } else {
-          selectSize("");
+          if (this.allowEmptySizeSelection) selectSize("");
         }
       },
       useCapture
@@ -371,6 +372,7 @@ class SwatchesVariationSelect extends AbstractSelect {
   constructor(element) {
     super(element, { event: "click", useCapture: true });
 
+    this.allowEmptySizeSelection = false;
     this.getSize = (e) => {
       const selected = e.target.closest("li");
       return selected?.dataset.value ?? "";

--- a/src/api/sizeme-api.js
+++ b/src/api/sizeme-api.js
@@ -548,10 +548,7 @@ function selectSize(size, auto) {
       }
       dispatch(actions.selectSize({ size, auto }));
     } else {
-      const selectedSize = SizeSelector.getSelectedSize();
-      if (selectedSize) {
-        dispatch(actions.selectSize({ size: selectedSize, auto: false }));
-      }
+      dispatch(actions.selectSize({ size: SizeSelector.getSelectedSize(), auto: false }));
     }
 
     let match = null;

--- a/src/api/sizeme-api.js
+++ b/src/api/sizeme-api.js
@@ -548,7 +548,10 @@ function selectSize(size, auto) {
       }
       dispatch(actions.selectSize({ size, auto }));
     } else {
-      dispatch(actions.selectSize({ size: SizeSelector.getSelectedSize(), auto: false }));
+      const selectedSize = SizeSelector.getSelectedSize();
+      if (selectedSize) {
+        dispatch(actions.selectSize({ size: selectedSize, auto: false }));
+      }
     }
 
     let match = null;


### PR DESCRIPTION
The invokeElement might be a larger clickable element where the size selections itself are children.
This means that in some cases it's possible to click outside a size selection with weird results.
This can now be disabled by setting allowEmptySizeSelection to false within a AbstractSelect class.