### PR TITLE
Change stretch calc to optimal

### DIFF
--- a/src/api/ProductModel.js
+++ b/src/api/ProductModel.js
@@ -2169,21 +2169,8 @@ const getResult = (measurement, value, matchItem) => {
   };
 };
 
-const stretchFactor = (measurement) => {
-  let factor = 1;
-  switch (measurement) {
-    case "pant_waist":
-      factor = 10;
-      break;
-    case "hips":
-      factor = 8;
-      break;
-  }
-  return factor;
-};
-
 const isStretching = (matchMap, effFitRecommendation) => {
-  if (effFitRecommendation === 1000) {
+  if (effFitRecommendation <= 1000) {
     return true;
   }
   if (!matchMap) {
@@ -2229,8 +2216,8 @@ const getFitPosition = (value, matchMap) => {
   if (matchMap) {
     const importanceArr = [];
     const componentFitArr = [];
-    Object.entries(matchMap).forEach(([oKey, oValue]) => {
-      maxStretchArr.push(oValue.componentStretch / stretchFactor(oKey));
+    Object.entries(matchMap).forEach(([, oValue]) => {
+      maxStretchArr.push(oValue.componentStretch);
       importanceArr.push(oValue.importance);
       componentFitArr.push(oValue.componentFit);
     });
@@ -2245,13 +2232,16 @@ const getFitPosition = (value, matchMap) => {
     let newPos = 50;
     if (matchMap) {
       if (effTotalFit > 1000) {
-        if (fitRecommendation === 1000) {
-          newPos = 60 + ((effTotalFit - 1000) / 55) * 40;
+        if (fitRecommendation <= 1000) {
+          newPos = 60 + ((effTotalFit - 1000) / 55) * 60;
         } else {
           newPos = 60 + ((effTotalFit - 1000) / 55) * 10;
         }
       } else if (effTotalFit == 1000) {
-        const stretchBreakpoint = 2 * DEFAULT_OPTIMAL_STRETCH;
+        let stretchBreakpoint = 2 * DEFAULT_OPTIMAL_STRETCH;
+        if (fitRecommendation < 1000) {
+          stretchBreakpoint = 2 * (1000 - fitRecommendation);
+        }
         const maxStretch = Math.max.apply(null, maxStretchArr);
         newPos =
           maxStretch > stretchBreakpoint
@@ -2308,8 +2298,6 @@ export {
   fitRanges,
   getResult,
   getFitPosition,
-  DEFAULT_OPTIMAL_FIT,
-  DEFAULT_OPTIMAL_STRETCH,
   fitLabelsAndColors,
   pinchedFits,
 };

--- a/test-sites/index1g.html
+++ b/test-sites/index1g.html
@@ -1,0 +1,862 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>STRETCHING BASE TOP (LOCAL-DB)</title>
+    <meta name="description" content="Just shirt with local measurements">
+    <meta name="keywords" content="Magento, Varien, E-commerce">
+    <meta name="robots" content="INDEX,FOLLOW">
+    <link rel="icon" href="https://www.sizemedemo.com/magento19/skin/frontend/default/default/favicon.ico"
+          type="image/x-icon">
+    <link rel="shortcut icon" href="https://www.sizemedemo.com/magento19/skin/frontend/default/default/favicon.ico"
+          type="image/x-icon">
+    <!--[if lt IE 7]>
+    <script type="text/javascript">
+        //<![CDATA[
+    var BLANK_URL = 'https://www.sizemedemo.com/magento19/js/blank.html';
+    var BLANK_IMG = 'https://www.sizemedemo.com/magento19/js/spacer.gif';
+//]]>
+</script>
+<![endif]-->
+    <link rel="stylesheet" type="text/css" href="https://www.sizemedemo.com/magento19/js/calendar/calendar-win2k-1.css">
+    <link rel="stylesheet" type="text/css"
+          href="https://www.sizemedemo.com/magento19/skin/frontend/default/default/css/styles.css" media="all">
+    <link rel="stylesheet" type="text/css"
+          href="https://www.sizemedemo.com/magento19/skin/frontend/base/default/css/widgets.css" media="all">
+    <link rel="stylesheet" type="text/css"
+          href="https://www.sizemedemo.com/magento19/skin/frontend/default/default/css/print.css" media="print">
+    <script async="" src="//www.google-analytics.com/analytics.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/prototype/prototype.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/lib/ccard.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/prototype/validation.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/scriptaculous/builder.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/scriptaculous/effects.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/scriptaculous/dragdrop.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/scriptaculous/controls.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/scriptaculous/slider.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/varien/js.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/varien/form.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/varien/menu.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/mage/translate.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/mage/cookies.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/varien/product.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/varien/product_options.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/varien/configurable.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/calendar/calendar.js"></script>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/calendar/calendar-setup.js"></script>
+    <!--[if lt IE 8]>
+    <link rel="stylesheet" type="text/css"
+          href="https://www.sizemedemo.com/magento19/skin/frontend/default/default/css/styles-ie.css" media="all"/>
+    <![endif]-->
+    <!--[if lt IE 7]>
+    <script type="text/javascript" src="https://www.sizemedemo.com/magento19/js/lib/ds-sleight.js"></script>
+    <script type="text/javascript"
+            src="https://www.sizemedemo.com/magento19/skin/frontend/base/default/js/ie6.js"></script>
+    <![endif]-->
+
+    <script type="text/javascript">
+        //<![CDATA[
+        Mage.Cookies.path = '/magento19';
+        Mage.Cookies.domain = '.www.sizemedemo.com';
+        //]]>
+    </script>
+
+    <script type="text/javascript">
+        //<![CDATA[
+        optionalZipCountries = ["HK", "IE", "MO", "PA"];
+        //]]>
+    </script>
+
+
+    <!--
+    <link rel="stylesheet" type="text/css" href="//sizeme.com/2.3/css/sizeme-magento.min.css" />
+    <script type="text/javascript" src="//sizeme.com/2.3/js/sizeme-magento.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="//test.sizeme.com/2.3/css/sizeme-magento.css">
+    -->
+    <script defer src="sizeme.js" type="text/javascript"></script>
+
+    <!--<script type="text/javascript" src="//test.sizeme.com/2.3/js/sizeme-magento.js"></script>-->
+    <!--
+    <script type="text/javascript">SizeMe.contextAddress = "https://test.sizeme.com";</script>
+    -->
+    <style type="text/css">.sizeme_slider table.slider_table td.too_small {
+        background-color: #444;
+    }
+
+    .sizeme_slider table.slider_table td.too_big {
+        background-color: #444;
+    }</style>
+    <script type="text/javascript">//<![CDATA[
+    var Translator = new Translate([]);
+    //]]></script>
+</head>
+<body class=" catalog-product-view catalog-product-view product-t-shirt-db">
+<div class="wrapper">
+    <noscript>
+        &lt;div class="global-site-notice noscript"&gt;
+        &lt;div class="notice-inner"&gt;
+        &lt;p&gt;
+        &lt;strong&gt;JavaScript seems to be disabled in your browser.&lt;/strong&gt;&lt;br /&gt;
+        You must have JavaScript enabled in your browser to utilize the functionality of this website. &lt;/p&gt;
+        &lt;/div&gt;
+        &lt;/div&gt;
+    </noscript>
+    <div class="page">
+        <div class="header-container">
+            <div class="header">
+                <a href="https://www.sizemedemo.com/magento19/" title="Magento Commerce" class="logo"><strong>Magento
+                    Commerce</strong><img
+                        src="https://www.sizemedemo.com/magento19/skin/frontend/default/default/images/logo.gif"
+                        alt="Magento Commerce"></a>
+                <div class="quick-access">
+                    <form id="search_mini_form" action="https://www.sizemedemo.com/magento19/catalogsearch/result/"
+                          method="get">
+                        <div class="form-search">
+                            <label for="search">Search:</label>
+                            <input id="search" type="text" name="q" value="" class="input-text" maxlength="128"
+                                   autocomplete="off">
+                            <button type="submit" title="Search" class="button"><span><span>Search</span></span>
+                            </button>
+                            <div id="search_autocomplete" class="search-autocomplete" style="display: none;"></div>
+                            <script type="text/javascript">
+                                //<![CDATA[
+                                var searchForm = new Varien.searchForm('search_mini_form', 'search', 'Search entire store here...');
+                                searchForm.initAutocomplete('https://www.sizemedemo.com/magento19/catalogsearch/ajax/suggest/', 'search_autocomplete');
+                                //]]>
+                            </script>
+                        </div>
+                    </form>
+                    <p class="welcome-msg">Default welcome msg! </p>
+                    <ul class="links">
+                        <li class="first"><a href="https://www.sizemedemo.com/magento19/customer/account/"
+                                             title="My Account">My Account</a></li>
+                        <li><a href="https://www.sizemedemo.com/magento19/wishlist/" title="My Wishlist">My Wishlist</a>
+                        </li>
+                        <li><a href="https://www.sizemedemo.com/magento19/checkout/cart/" title="My Cart"
+                               class="top-link-cart">My Cart</a></li>
+                        <li><a href="https://www.sizemedemo.com/magento19/checkout/" title="Checkout"
+                               class="top-link-checkout">Checkout</a></li>
+                        <li class=" last"><a href="https://www.sizemedemo.com/magento19/customer/account/login/"
+                                             title="Log In">Log In</a></li>
+                    </ul>
+                    <div class="form-language">
+                        <label for="select-language">Choose theme:</label>
+                        <select id="select-language" title="Choose theme" onchange="window.location.href=this.value">
+                            <option value="https://www.sizemedemo.com/magento19/t-shirt-db.html?___store=default&amp;___from_store=default"
+                                    selected="selected">Default Theme
+                            </option>
+                            <option value="https://www.sizemedemo.com/magento19/t-shirt-db.html?___store=default_buttons&amp;___from_store=default">
+                                Default Theme with Buttons
+                            </option>
+                            <option value="https://www.sizemedemo.com/magento19/t-shirt-db.html?___store=rwd&amp;___from_store=default">
+                                RWD Theme
+                            </option>
+                        </select>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="main-container col2-right-layout">
+            <div class="main">
+                <div class="breadcrumbs">
+                    <ul>
+                        <li class="home">
+                            <a href="https://www.sizemedemo.com/magento19/" title="Go to Home Page">Home</a>
+                            <span>/ </span>
+                        </li>
+                        <li class="product">
+                            <strong>BASE LAYER SET (PRODUCT-DB)</strong>
+                        </li>
+                    </ul>
+                </div>
+                <div class="col-main">
+                    <script type="text/javascript">
+                        var optionsPrice = new Product.OptionsPrice({
+                            "priceFormat": {
+                                "pattern": "\u20ac%s",
+                                "precision": 2,
+                                "requiredPrecision": 2,
+                                "decimalSymbol": ".",
+                                "groupSymbol": ",",
+                                "groupLength": 3,
+                                "integerRequired": 1
+                            },
+                            "includeTax": "false",
+                            "showIncludeTax": false,
+                            "showBothPrices": false,
+                            "idSuffix": "",
+                            "oldPlusDisposition": 0,
+                            "plusDisposition": 0,
+                            "plusDispositionTax": 0,
+                            "oldMinusDisposition": 0,
+                            "minusDisposition": 0,
+                            "productId": "15",
+                            "productPrice": 10,
+                            "productOldPrice": 10,
+                            "priceInclTax": 10,
+                            "priceExclTax": 10,
+                            "skipCalculate": 1,
+                            "defaultTax": 8.25,
+                            "currentTax": 0,
+                            "tierPrices": [],
+                            "tierPricesInclTax": [],
+                            "swatchPrices": null
+                        });
+                    </script>
+                    <div id="messages_product_view"></div>
+                    <div class="product-view">
+                        <div class="product-essential">
+                            <form action="https://www.sizemedemo.com/magento19/checkout/cart/add/uenc/aHR0cHM6Ly93d3cuc2l6ZW1lZGVtby5jb20vbWFnZW50bzE5L3Qtc2hpcnQtZGIuaHRtbD9fX19TSUQ9VQ,,/product/15/form_key/BAd4YDwltwnKcByI/"
+                                  method="post" id="product_addtocart_form">
+                                <input name="form_key" type="hidden" value="BAd4YDwltwnKcByI">
+                                <div class="no-display">
+                                    <input type="hidden" name="product" value="15">
+                                    <input type="hidden" name="related_product" id="related-products-field" value="">
+                                </div>
+
+                                <div class="product-shop">
+                                    <div class="product-name">
+                                        <h1>BASE SHIRT (LOCAL-DB)</h1>
+                                    </div>
+
+                                    <p class="email-friend"><a
+                                            href="https://www.sizemedemo.com/magento19/sendfriend/product/send/id/15/">Email
+                                        to a Friend</a></p>
+
+                                    <p class="no-rating"><a
+                                            href="https://www.sizemedemo.com/magento19/review/product/list/id/15/#review-form">Be
+                                        the first to review this product</a></p>
+
+                                    <p class="availability in-stock">Availability: <span>In stock</span></p>
+
+
+                                    <div class="price-box">
+                                                                <span class="regular-price" id="product-price-15">
+                                            <span class="price">€10.00</span>                                    </span>
+
+                                    </div>
+
+
+                                    <div class="short-description">
+                                        <h2>Quick Overview</h2>
+                                        <div class="std">Base Shirt Local DB</div>
+                                    </div>
+
+
+                                    <div class="product-options" id="product-options-wrapper">
+
+                                        <dl class="last">
+                                            <dt><label class="required"><em>*</em>Size</label></dt>
+                                            <dd class="last">
+                                                <div class="input-box">
+                                                    <select name="super_attribute[132]" id="attribute132"
+                                                            class="required-entry super-attribute-select sizeme-magento-size-selector">
+
+                                                        <option value="">Choose an Option...</option>
+                                                        <option value="7" price="0">S</option>
+                                                        <option value="6" price="0">M</option>
+                                                        <option value="4" price="0">XL</option>
+                                                        <option value="5" price="0">L</option>
+                                                    </select>
+                                                </div>
+                                            </dd>
+                                        </dl>
+                                        <script type="text/javascript">
+                                            var spConfig = new Product.Config({
+                                                "attributes": {
+                                                    "132": {
+                                                        "id": "132",
+                                                        "code": "size",
+                                                        "label": "Size",
+                                                        "options": [{
+                                                            "id": "7",
+                                                            "label": "S",
+                                                            "price": "0",
+                                                            "oldPrice": "0",
+                                                            "products": ["16"]
+                                                        }, {
+                                                            "id": "6",
+                                                            "label": "M",
+                                                            "price": "0",
+                                                            "oldPrice": "0",
+                                                            "products": ["17"]
+                                                        }, {
+                                                            "id": "5",
+                                                            "label": "L",
+                                                            "price": "0",
+                                                            "oldPrice": "0",
+                                                            "products": ["18"]
+                                                        }, {
+                                                            "id": "4",
+                                                            "label": "XL",
+                                                            "price": "0",
+                                                            "oldPrice": "0",
+                                                            "products": ["19"]
+                                                        }]
+                                                    }
+                                                },
+                                                "template": "\u20ac#{price}",
+                                                "basePrice": "10",
+                                                "oldPrice": "10",
+                                                "productId": "15",
+                                                "chooseText": "Choose an Option...",
+                                                "taxConfig": {
+                                                    "includeTax": false,
+                                                    "showIncludeTax": false,
+                                                    "showBothPrices": false,
+                                                    "defaultTax": 8.25,
+                                                    "currentTax": 0,
+                                                    "inclTaxTitle": "Incl. Tax"
+                                                }
+                                            });
+                                        </script>
+                                        <script type="text/javascript">
+                                            //<![CDATA[
+                                            var DateOption = Class.create({
+
+                                                getDaysInMonth: function (month, year) {
+                                                    var curDate = new Date();
+                                                    if (!month) {
+                                                        month = curDate.getMonth();
+                                                    }
+                                                    if (2 == month && !year) { // leap year assumption for unknown year
+                                                        return 29;
+                                                    }
+                                                    if (!year) {
+                                                        year = curDate.getFullYear();
+                                                    }
+                                                    return 32 - new Date(year, month - 1, 32).getDate();
+                                                },
+
+                                                reloadMonth: function (event) {
+                                                    var selectEl = event.findElement();
+                                                    var idParts = selectEl.id.split("_");
+                                                    if (idParts.length != 3) {
+                                                        return false;
+                                                    }
+                                                    var optionIdPrefix = idParts[0] + "_" + idParts[1];
+                                                    var month = parseInt($(optionIdPrefix + "_month").value);
+                                                    var year = parseInt($(optionIdPrefix + "_year").value);
+                                                    var dayEl = $(optionIdPrefix + "_day");
+
+                                                    var days = this.getDaysInMonth(month, year);
+
+                                                    //remove days
+                                                    for (var i = dayEl.options.length - 1; i >= 0; i--) {
+                                                        if (dayEl.options[i].value > days) {
+                                                            dayEl.remove(dayEl.options[i].index);
+                                                        }
+                                                    }
+
+                                                    // add days
+                                                    var lastDay = parseInt(dayEl.options[dayEl.options.length - 1].value);
+                                                    for (i = lastDay + 1; i <= days; i++) {
+                                                        this.addOption(dayEl, i, i);
+                                                    }
+                                                },
+
+                                                addOption: function (select, text, value) {
+                                                    var option = document.createElement('OPTION');
+                                                    option.value = value;
+                                                    option.text = text;
+
+                                                    if (select.options.add) {
+                                                        select.options.add(option);
+                                                    } else {
+                                                        select.appendChild(option);
+                                                    }
+                                                }
+                                            });
+                                            dateOption = new DateOption();
+                                            //]]>
+                                        </script>
+
+
+                                        <script type="text/javascript">
+                                            //<![CDATA[
+                                            enUS = {
+                                                "m": {
+                                                    "wide": ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+                                                    "abbr": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+                                                }
+                                            }; // en_US locale reference
+                                            Calendar._DN = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]; // full day names
+                                            Calendar._SDN = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]; // short day names
+                                            Calendar._FD = 1; // First day of the week. "0" means display Sunday first, "1" means display Monday first, etc.
+                                            Calendar._MN = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]; // full month names
+                                            Calendar._SMN = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]; // short month names
+                                            Calendar._am = "AM"; // am/pm
+                                            Calendar._pm = "PM";
+
+                                            // tooltips
+                                            Calendar._TT = {};
+                                            Calendar._TT["INFO"] = 'About the calendar';
+
+                                            Calendar._TT["ABOUT"] =
+                                                'DHTML Date/Time Selector\n' +
+                                                "(c) dynarch.com 2002-2005 / Author: Mihai Bazon\n" +
+                                                'For latest version visit: http://www.dynarch.com/projects/calendar/\n' +
+                                                'Distributed under GNU LGPL. See http://gnu.org/licenses/lgpl.html for details.' +
+                                                '\n\n' +
+                                                'Date selection:\n' +
+                                                '- Use the \xab, \xbb buttons to select year\n' +
+                                                '- Use the \u2039 buttons to select month\n' +
+                                                '- Hold mouse button on any of the above buttons for faster selection.';
+                                            Calendar._TT["ABOUT_TIME"] = '\n\n' +
+                                                'Time selection:\n' +
+                                                '- Click on any of the time parts to increase it\n' +
+                                                '- or Shift-click to decrease it\n' +
+                                                '- or click and drag for faster selection.';
+
+                                            Calendar._TT["PREV_YEAR"] = 'Prev. year (hold for menu)';
+                                            Calendar._TT["PREV_MONTH"] = 'Prev. month (hold for menu)';
+                                            Calendar._TT["GO_TODAY"] = 'Go Today';
+                                            Calendar._TT["NEXT_MONTH"] = 'Next month (hold for menu)';
+                                            Calendar._TT["NEXT_YEAR"] = 'Next year (hold for menu)';
+                                            Calendar._TT["SEL_DATE"] = 'Select date';
+                                            Calendar._TT["DRAG_TO_MOVE"] = 'Drag to move';
+                                            Calendar._TT["PART_TODAY"] = ' (' + "today" + ')';
+
+                                            // the following is to inform that "%s" is to be the first day of week
+                                            Calendar._TT["DAY_FIRST"] = 'Display %s first';
+
+                                            // This may be locale-dependent. It specifies the week-end days, as an array
+                                            // of comma-separated numbers. The numbers are from 0 to 6: 0 means Sunday, 1
+                                            // means Monday, etc.
+                                            Calendar._TT["WEEKEND"] = "0,6";
+
+                                            Calendar._TT["CLOSE"] = 'Close';
+                                            Calendar._TT["TODAY"] = "today";
+                                            Calendar._TT["TIME_PART"] = '(Shift-)Click or drag to change value';
+
+                                            // date formats
+                                            Calendar._TT["DEF_DATE_FORMAT"] = "%b %e, %Y";
+                                            Calendar._TT["TT_DATE_FORMAT"] = "%B %e, %Y";
+
+                                            Calendar._TT["WK"] = "Week";
+                                            Calendar._TT["TIME"] = 'Time:';
+                                            //]]>
+                                        </script>
+                                        <p class="required">* Required Fields</p>
+                                    </div>
+                                    <script type="text/javascript">decorateGeneric($$('#product-options-wrapper dl'), ['last']);</script>
+                                    <div class="product-options-bottom">
+
+
+                                        <div class="price-box">
+                                                                <span class="regular-price" id="product-price-15_clone">
+                                            <span class="price">€10.00</span>                                    </span>
+
+                                        </div>
+
+                                        <div class="add-to-cart">
+                                            <label for="qty">Qty:</label>
+                                            <input type="text" name="qty" id="qty" maxlength="12" value="1" title="Qty"
+                                                   class="input-text qty">
+                                            <button type="button" title="Add to Cart" id="product-addtocart-button"
+                                                    class="button btn-cart" onclick="productAddToCartForm.submit(this)">
+                                                <span><span>Add to Cart</span></span></button>
+                                        </div>
+
+
+                                        <ul class="add-to-links">
+                                            <li>
+                                                <a href="https://www.sizemedemo.com/magento19/wishlist/index/add/product/15/form_key/BAd4YDwltwnKcByI/"
+                                                   onclick="productAddToCartForm.submitLight(this, this.href); return false;"
+                                                   class="link-wishlist">Add to Wishlist</a></li>
+                                            <li><span class="separator">|</span> <a
+                                                    href="https://www.sizemedemo.com/magento19/catalog/product_compare/add/product/15/uenc/aHR0cHM6Ly93d3cuc2l6ZW1lZGVtby5jb20vbWFnZW50bzE5L3Qtc2hpcnQtZGIuaHRtbA,,/form_key/BAd4YDwltwnKcByI/"
+                                                    class="link-compare">Add to Compare</a></li>
+                                        </ul>
+                                    </div>
+
+                                </div>
+
+                                <div class="product-img-box">
+                                    <p class="product-image product-image-zoom">
+                                        <img id="image"
+                                             src="https://www.sizemedemo.com/magento19/media/catalog/product/cache/1/image/9df78eab33525d08d6e5fb8d27136e95/b/l/black_tshirt_2.png"
+                                             alt="T-SHIRT (PRODUCT-DB)" title="T-SHIRT (PRODUCT-DB)"
+                                             style="width: 265px; left: 0px; top: 5.5px;"></p>
+                                    <p class="zoom-notice" id="track_hint">Double click on above image to view full
+                                        picture</p>
+                                    <div class="zoom">
+                                        <img id="zoom_out"
+                                             src="https://www.sizemedemo.com/magento19/skin/frontend/default/default/images/slider_btn_zoom_out.gif"
+                                             alt="Zoom Out" title="Zoom Out" class="btn-zoom-out">
+                                        <div id="track">
+                                            <div id="handle" class="selected" style="left: 0px;"></div>
+                                        </div>
+                                        <img id="zoom_in"
+                                             src="https://www.sizemedemo.com/magento19/skin/frontend/default/default/images/slider_btn_zoom_in.gif"
+                                             alt="Zoom In" title="Zoom In" class="btn-zoom-in">
+                                    </div>
+
+                                    <div class="more-views">
+                                        <h2>More Views</h2>
+                                        <ul>
+                                            <li>
+                                                <a href="#"
+                                                   onclick="popWin('https://www.sizemedemo.com/magento19/catalog/product/gallery/id/15/image/12/', 'gallery', 'width=300,height=300,left=0,top=0,location=no,status=yes,scrollbars=yes,resizable=yes'); return false;"
+                                                   title=""><img
+                                                        src="https://www.sizemedemo.com/magento19/media/catalog/product/cache/1/thumbnail/56x/9df78eab33525d08d6e5fb8d27136e95/b/l/black_tshirt_2.png"
+                                                        width="56" height="56" alt=""></a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+
+                                <div class="clearer"></div>
+                            </form>
+                            <script type="text/javascript">
+                                //<![CDATA[
+                                var productAddToCartForm = new VarienForm('product_addtocart_form');
+                                productAddToCartForm.submit = function (button, url) {
+                                    if (this.validator.validate()) {
+                                        var form = this.form;
+                                        var oldUrl = form.action;
+
+                                        if (url) {
+                                            form.action = url;
+                                        }
+                                        var e = null;
+                                        try {
+                                            this.form.submit();
+                                        } catch (e) {
+                                        }
+                                        this.form.action = oldUrl;
+                                        if (e) {
+                                            throw e;
+                                        }
+
+                                        if (button && button != 'undefined') {
+                                            button.disabled = true;
+                                        }
+                                    }
+                                }.bind(productAddToCartForm);
+
+                                productAddToCartForm.submitLight = function (button, url) {
+                                    if (this.validator) {
+                                        var nv = Validation.methods;
+                                        delete Validation.methods['required-entry'];
+                                        delete Validation.methods['validate-one-required'];
+                                        delete Validation.methods['validate-one-required-by-name'];
+                                        // Remove custom datetime validators
+                                        for (var methodName in Validation.methods) {
+                                            if (methodName.match(/^validate-datetime-.*/i)) {
+                                                delete Validation.methods[methodName];
+                                            }
+                                        }
+
+                                        if (this.validator.validate()) {
+                                            if (url) {
+                                                this.form.action = url;
+                                            }
+                                            this.form.submit();
+                                        }
+                                        Object.extend(Validation.methods, nv);
+                                    }
+                                }.bind(productAddToCartForm);
+                                //]]>
+                            </script>
+                        </div>
+
+                        <div class="product-collateral">
+                            <div class="box-collateral box-description">
+                                <h2>Details</h2>
+                                <div class="std">
+                                    Just a base layer shirt with local measurements
+                                </div>
+                            </div>
+                            <div class="box-collateral box-tags">
+                                <h2>Product Tags</h2>
+                                <form id="addTagForm"
+                                      action="https://www.sizemedemo.com/magento19/tag/index/save/product/15/uenc/aHR0cHM6Ly93d3cuc2l6ZW1lZGVtby5jb20vbWFnZW50bzE5L3Qtc2hpcnQtZGIuaHRtbA,,/"
+                                      method="get">
+                                    <div class="form-add">
+                                        <label for="productTagName">Add Your Tags:</label>
+                                        <div class="input-box">
+                                            <input type="text" class="input-text required-entry" name="productTagName"
+                                                   id="productTagName">
+                                        </div>
+                                        <button type="button" title="Add Tags" class="button" onclick="submitTagForm()">
+                <span>
+                    <span>Add Tags</span>
+                </span>
+                                        </button>
+                                    </div>
+                                </form>
+                                <p class="note">Use spaces to separate tags. Use single quotes (') for phrases.</p>
+                                <script type="text/javascript">
+                                    //<![CDATA[
+                                    var addTagFormJs = new VarienForm('addTagForm');
+                                    function submitTagForm() {
+                                        if (addTagFormJs.validator.validate()) {
+                                            addTagFormJs.form.submit();
+                                        }
+                                    }
+                                    //]]>
+                                </script>
+                            </div>
+                        </div>
+                    </div>
+
+
+                    <!--<script type="text/javascript">
+                        //<![CDATA[
+                        var sizeme_product = {
+                            name: "BASE LAYER SET",
+                            SKU: "DEMO-HALTI-088-0119",
+                            item: {
+                                "DEMO-HALTI-088-0119-S": "7",
+                                "DEMO-HALTI-088-0119-M": "6",
+                                "DEMO-HALTI-088-0119-L": "5",
+                                "DEMO-HALTI-088-0119-XL": "4",
+                            }
+                        };
+                        //]]>
+                    </script>-->
+
+                    <script type="text/javascript">
+                        //<![CDATA[
+                        var sizeme_product = {
+                            name: "T-SHIRT",
+                            item: {
+                                itemType: "1.1.1.6.1.4.0",
+                                itemLayer: 0,
+                                itemThickness: 1,
+                                itemStretch:	50,
+                                fitRecommendation: 900,
+                                measurements: {
+                                    "7": {
+                                        "chest": 350,
+                                        "waist": 350,
+                                        "sleeve": 625,
+                                        "sleeve_top_width": 0,
+                                        "wrist_width": 0,
+                                        "underbust": 0,
+                                        "neck_opening_width": 0,
+                                        "shoulder_width": 0,
+                                        "front_height": 750,
+                                        "pant_waist": 0,
+                                        "hips": 350,
+                                        "inseam": 0,
+                                        "outseam": 0,
+                                        "thigh_width": 0,
+                                        "knee_width": 0,
+                                        "calf_width": 0,
+                                        "pant_sleeve_width": 0,
+                                        "shoe_inside_length": 0,
+                                        "shoe_inside_width": 0,
+                                        "hat_width": 0,
+                                        "hood_height": 0,
+                                    },
+                                    "6": {
+                                        "chest": 370,
+                                        "waist": 370,
+                                        "sleeve": 640,
+                                        "sleeve_top_width": 0,
+                                        "wrist_width": 0,
+                                        "underbust": 0,
+                                        "neck_opening_width": 0,
+                                        "shoulder_width": 0,
+                                        "front_height": 770,
+                                        "pant_waist": 0,
+                                        "hips": 370,
+                                        "inseam": 0,
+                                        "outseam": 0,
+                                        "thigh_width": 0,
+                                        "knee_width": 0,
+                                        "calf_width": 0,
+                                        "pant_sleeve_width": 0,
+                                        "shoe_inside_length": 0,
+                                        "shoe_inside_width": 0,
+                                        "hat_width": 0,
+                                        "hood_height": 0,
+                                    },
+                                    "5": {
+                                        "chest": 390,
+                                        "waist": 390,
+                                        "sleeve": 655,
+                                        "sleeve_top_width": 0,
+                                        "wrist_width": 0,
+                                        "underbust": 0,
+                                        "neck_opening_width": 0,
+                                        "shoulder_width": 0,
+                                        "front_height": 790,
+                                        "pant_waist": 0,
+                                        "hips": 390,
+                                        "inseam": 0,
+                                        "outseam": 0,
+                                        "thigh_width": 0,
+                                        "knee_width": 0,
+                                        "calf_width": 0,
+                                        "pant_sleeve_width": 0,
+                                        "shoe_inside_length": 0,
+                                        "shoe_inside_width": 0,
+                                        "hat_width": 0,
+                                        "hood_height": 0,
+                                    },
+                                    "4": {
+                                        "chest": 410,
+                                        "waist": 410,
+                                        "sleeve": 670,
+                                        "sleeve_top_width": 0,
+                                        "wrist_width": 0,
+                                        "underbust": 0,
+                                        "neck_opening_width": 0,
+                                        "shoulder_width": 0,
+                                        "front_height": 810,
+                                        "pant_waist": 0,
+                                        "hips": 410,
+                                        "inseam": 0,
+                                        "outseam": 0,
+                                        "thigh_width": 0,
+                                        "knee_width": 0,
+                                        "calf_width": 0,
+                                        "pant_sleeve_width": 0,
+                                        "shoe_inside_length": 0,
+                                        "shoe_inside_width": 0,
+                                        "hat_width": 0,
+                                        "hood_height": 0,
+                                    },
+                                }
+                            }
+                        };
+                        //]]>
+                    </script>-->
+
+
+                    <script type="text/javascript">
+                        var lifetime = 3600;
+                        var expireAt = Mage.Cookies.expires;
+                        if (lifetime > 0) {
+                            expireAt = new Date();
+                            expireAt.setTime(expireAt.getTime() + lifetime * 1000);
+                        }
+                        Mage.Cookies.set('external_no_cache', 1, expireAt);
+                    </script>
+                </div>
+                <div class="col-right sidebar">
+                    <div class="block block-cart">
+                        <div class="block-title">
+                            <strong><span>My Cart</span></strong>
+                        </div>
+                        <div class="block-content">
+                            <p class="empty">You have no items in your shopping cart.</p>
+                        </div>
+                    </div>
+                    <div class="block block-banner">
+                        <div class="block-content">
+                            <img src="https://www.sizemedemo.com/magento19/skin/frontend/default/default/images/media/col_right_callout.jpg"
+                                 title="Keep your eyes open for our special Back to School items and save A LOT!"
+                                 alt="Keep your eyes open for our special Back to School items and save A LOT!">
+                        </div>
+                    </div>
+                    <script type="text/javascript">
+                        //<![CDATA[
+                        function validatePollAnswerIsSelected() {
+                            var options = $$('input.poll_vote');
+                            for (i in options) {
+                                if (options[i].checked == true) {
+                                    return true;
+                                }
+                            }
+                            return false;
+                        }
+                        //]]>
+                    </script>
+                    <div class="block block-poll">
+                        <div class="block-title">
+                            <strong><span>Community Poll</span></strong>
+                        </div>
+                        <form id="pollForm" action="https://www.sizemedemo.com/magento19/poll/vote/add/poll_id/1/"
+                              method="post" onsubmit="return validatePollAnswerIsSelected();">
+                            <div class="block-content">
+                                <p class="block-subtitle">What is your favorite color</p>
+                                <ul id="poll-answers">
+                                    <li class="odd">
+                                        <input type="radio" name="vote" class="radio poll_vote" id="vote_1" value="1">
+                                        <span class="label"><label for="vote_1">Green</label></span>
+                                    </li>
+                                    <li class="even">
+                                        <input type="radio" name="vote" class="radio poll_vote" id="vote_2" value="2">
+                                        <span class="label"><label for="vote_2">Red</label></span>
+                                    </li>
+                                    <li class="odd">
+                                        <input type="radio" name="vote" class="radio poll_vote" id="vote_3" value="3">
+                                        <span class="label"><label for="vote_3">Black</label></span>
+                                    </li>
+                                    <li class="last even">
+                                        <input type="radio" name="vote" class="radio poll_vote" id="vote_4" value="4">
+                                        <span class="label"><label for="vote_4">Magenta</label></span>
+                                    </li>
+                                </ul>
+                                <script type="text/javascript">decorateList('poll-answers');</script>
+                                <div class="actions">
+                                    <button type="submit" title="Vote" class="button"><span><span>Vote</span></span>
+                                    </button>
+                                </div>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="paypal-logo">
+                        <a href="#" title="Additional Options"
+                           onclick="javascript:window.open('https://www.paypal.com/us/cgi-bin/webscr?cmd=xpt/Marketing/popup/OLCWhatIsPayPal-outside','paypal','width=600,height=350,left=0,top=0,location=no,status=yes,scrollbars=yes,resizable=yes'); return false;"><img
+                                src="https://www.paypalobjects.com/en_US/i/bnr/bnr_nowAccepting_150x60.gif"
+                                alt="Additional Options" title="Additional Options"></a>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="footer-container">
+            <div class="footer">
+
+                <ul>
+                    <li><a href="https://www.sizemedemo.com/magento19/about-magento-demo-store">About Us</a></li>
+                    <li><a href="https://www.sizemedemo.com/magento19/customer-service">Customer Service</a></li>
+                    <li class="last privacy"><a
+                            href="https://www.sizemedemo.com/magento19/privacy-policy-cookie-restriction-mode">Privacy
+                        Policy</a></li>
+                </ul>
+                <ul class="links">
+                    <li class="first"><a href="https://www.sizemedemo.com/magento19/catalog/seo_sitemap/category/"
+                                         title="Site Map">Site Map</a></li>
+                    <li><a href="https://www.sizemedemo.com/magento19/catalogsearch/term/popular/" title="Search Terms">Search
+                        Terms</a></li>
+                    <li><a href="https://www.sizemedemo.com/magento19/catalogsearch/advanced/" title="Advanced Search">Advanced
+                        Search</a></li>
+                    <li><a href="https://www.sizemedemo.com/magento19/sales/guest/form/" title="Orders and Returns">Orders
+                        and Returns</a></li>
+                    <li class=" last"><a href="https://www.sizemedemo.com/magento19/contacts/" title="Contact Us">Contact
+                        Us</a></li>
+                </ul>
+                <p class="bugs">Help Us to Keep Magento Healthy - <a href="http://www.magentocommerce.com/bug-tracking"
+                                                                     onclick="this.target='_blank'"><strong>Report All
+                    Bugs</strong></a> (ver. 1.9.3.0)</p>
+                <address>© 2016 Magento Demo Store. All Rights Reserved.</address>
+            </div>
+        </div>
+
+
+    </div>
+</div>
+
+<script type="text/javascript">
+    var sizeme_options = {
+        serviceStatus: true,
+        pluginVersion: "MAG1-0.1.0",
+        contextAddress: "https://test.sizeme.com",
+        gaTrackingId: "UA-40735596-2",
+        shopType: "magento",
+        debugState: false,
+        uiOptions: {
+            toggler: false,
+            flatMeasurements: false
+        }
+    };
+</script>
+
+<script type="text/javascript" src="//code.jquery.com/jquery-1.12.4.min.js"></script>
+<script>jQuery.noConflict();</script>
+</body>
+</html>


### PR DESCRIPTION
Previously, the fit recommendation value of 1000 has been to indicate skin-tight clothing with **fixed** optimal stretching values that were gained from previous real-life testing.  This was boosted with a semi-weird stretch factor that in effect had different optimals for different measurement pairs (pant waist foremost).  

This has turned out to be sub-optimal, so instead of introducing a new separate value to the product db, the fit recommendation value from 900 to 1000 will now represent optimal stretch values from 100 to 0 respectively.  This will allow the optimal stretch (which is a percentage value of actual stretching vs. all possible stretching) value to be set product-by-product.  The value is compared to the max of all stretching components (the "worst" stretcher).  

The user interface doesn't separate the different stretching values by a lot as all are usually in the "recommended" zone.  This might have to be looked at at some point.  